### PR TITLE
Add timezone and date_format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Format datum to jsonl, 1 json per 1 line
     - CR: use `\r`(0x0d) as newline character
     - NUL: use `\0`(0x00) instead of newline (for example, `xargs -0` will be good friend with it)
     - NO: dump JSONs in a line
+- **date_format**: date format. ex: "yyyy-MM-dd'P'HH:mm:ss.SSSX" (string default: nil)
+- **timezone**: timezone. "JST" (string default: nil)
 
 ## Example
 

--- a/lib/embulk/formatter/jsonl.rb
+++ b/lib/embulk/formatter/jsonl.rb
@@ -27,6 +27,8 @@ module Embulk
         task = {
           'encoding' => config.param('encoding', :string, default: 'UTF-8'),
           'newline' => config.param('newline', :string, default: 'LF'),
+          'date_format' => config.param('date_format', :string, default: nil),
+          'timezone' => config.param('timezone', :string, default: nil )
         }
 
         encoding = task['encoding'].upcase
@@ -46,6 +48,11 @@ module Embulk
         # your data
         @current_file == nil
         @current_file_size = 0
+        @opts = { :mode => :compat }
+        date_format = task['date_format']
+        timezone = task['timezone']
+        @opts[:date_format] = date_format if date_format
+        @opts[:timezone] = timezone if timezone
       end
 
       def close
@@ -62,7 +69,7 @@ module Embulk
           @schema.each do |col|
             datum[col.name] = record[col.index]
           end
-          @current_file.write "#{JrJackson::Json.dump(datum, :mode => :compat)}#{@newline}".encode(@encoding)
+          @current_file.write "#{JrJackson::Json.dump(datum, @opts )}#{@newline}".encode(@encoding)
         end
       end
 


### PR DESCRIPTION
Due to CSV parser does not quote comma like ",", embulk-output-bigquery need to use this formater. 

However, this plugin need to modify timestamp format. BQ can't use timezone +9:00.

See also [Twitter timeline](https://twitter.com/y_110/status/588274920473264128) Japanese. 
